### PR TITLE
support uncompressed key for legacy bitcoin addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2 (2022-03-14)
+
+- Support uncompressed public keys for legacy addresses ([#12](https://github.com/ayrat555/cryptopunk/pull/12))
+
 ## 0.5.1 (2022-03-12)
 
 - Use ex_base58 NIF ([#11](https://github.com/ayrat555/cryptopunk/pull/11))

--- a/lib/cryptopunk/crypto/bitcoin.ex
+++ b/lib/cryptopunk/crypto/bitcoin.ex
@@ -13,10 +13,11 @@ defmodule Cryptopunk.Crypto.Bitcoin do
   @doc """
   Generate a legacy (P2PKH) address.
 
-  It accepts two parameters:
+  It accepts three parameters:
 
   - public or private key. if a private key is provided, it will be converted to public key.
   - network (`:mainnet` or `:testnet`)
+  - optional keyword params. Currently, the only allowed parameter is `:uncompressed` key. Passing `[uncompressed: true]` will generate the address from the uncompressed public key which is not advised. but it may be required for compatibility reasons
 
   Examples:
 
@@ -27,6 +28,10 @@ defmodule Cryptopunk.Crypto.Bitcoin do
       iex> public_key = %Cryptopunk.Key{key: <<4, 57, 163, 96, 19, 48, 21, 151, 218, 239, 65, 251, 229, 147, 160, 44, 197, 19, 208, 181, 85, 39, 236, 45, 241, 5, 14, 46, 143, 244, 156, 133, 194, 60, 190, 125, 237, 14, 124, 230, 165, 148, 137, 107, 143, 98, 136, 143, 219, 197, 200, 130, 19, 5, 226, 234, 66, 191, 1, 227, 115, 0, 17, 98, 129>>, type: :public}
       iex> Cryptopunk.Crypto.Bitcoin.legacy_address(public_key, :testnet)
       "mkHGce7dctSxHgaWSSbmmrRWsZfzz7MxMk"
+
+      iex> private_key = %Cryptopunk.Key{key: <<16, 42, 130, 92, 247, 244, 62, 96, 24, 129, 187, 141, 124, 42, 176, 116, 234, 171, 184, 107, 3, 229, 255, 72, 30, 116, 79, 243, 36, 142, 184, 24>>, type: :private}
+      iex> Cryptopunk.Crypto.Bitcoin.legacy_address(private_key, :mainnet, uncompressed: true)
+      "1AqWUNX6mdaiPay55BqZcAMqNSEJgcgj1D"
   """
   @spec legacy_address(Key.t(), atom() | binary(), Keyword.t()) :: String.t()
   def legacy_address(private_or_public_key, net_or_version_byte, opts \\ []) do

--- a/lib/cryptopunk/crypto/bitcoin.ex
+++ b/lib/cryptopunk/crypto/bitcoin.ex
@@ -29,7 +29,7 @@ defmodule Cryptopunk.Crypto.Bitcoin do
       "mkHGce7dctSxHgaWSSbmmrRWsZfzz7MxMk"
   """
   @spec legacy_address(Key.t(), atom() | binary(), Keyword.t()) :: String.t()
-  def legacy_address(private_or_public_key, net_or_version_byte, opts) do
+  def legacy_address(private_or_public_key, net_or_version_byte, opts \\ []) do
     address(private_or_public_key, net_or_version_byte, :legacy, opts)
   end
 
@@ -97,7 +97,7 @@ defmodule Cryptopunk.Crypto.Bitcoin do
   end
 
   defp generate_address(public_key, net_or_version_byte, :legacy, opts) do
-    LegacyAddress.address(public_key, net_or_version_byte)
+    LegacyAddress.address(public_key, net_or_version_byte, opts)
   end
 
   defp generate_address(public_key, net_or_version_byte, :p2sh_p2wpkh, _opts) do

--- a/lib/cryptopunk/crypto/bitcoin.ex
+++ b/lib/cryptopunk/crypto/bitcoin.ex
@@ -28,9 +28,9 @@ defmodule Cryptopunk.Crypto.Bitcoin do
       iex> Cryptopunk.Crypto.Bitcoin.legacy_address(public_key, :testnet)
       "mkHGce7dctSxHgaWSSbmmrRWsZfzz7MxMk"
   """
-  @spec legacy_address(Key.t(), atom() | binary()) :: String.t()
-  def legacy_address(private_or_public_key, net_or_version_byte) do
-    address(private_or_public_key, net_or_version_byte, :legacy)
+  @spec legacy_address(Key.t(), atom() | binary(), Keyword.t()) :: String.t()
+  def legacy_address(private_or_public_key, net_or_version_byte, opts) do
+    address(private_or_public_key, net_or_version_byte, :legacy, opts)
   end
 
   @doc """
@@ -96,7 +96,7 @@ defmodule Cryptopunk.Crypto.Bitcoin do
     generate_address(public_key, net_or_version_byte, type, opts)
   end
 
-  defp generate_address(public_key, net_or_version_byte, :legacy, _opts) do
+  defp generate_address(public_key, net_or_version_byte, :legacy, opts) do
     LegacyAddress.address(public_key, net_or_version_byte)
   end
 

--- a/lib/cryptopunk/crypto/bitcoin/legacy_address.ex
+++ b/lib/cryptopunk/crypto/bitcoin/legacy_address.ex
@@ -9,20 +9,26 @@ defmodule Cryptopunk.Crypto.Bitcoin.LegacyAddress do
     testnet: 111
   }
 
-  @spec address(Key.t(), atom() | binary()) :: String.t()
-  def address(public_key, net) when is_atom(net) do
+  @spec address(Key.t(), atom() | binary(), Keyword.t()) :: String.t()
+  def address(public_key, net, opts) when is_atom(net) do
     version_byte = Map.fetch!(@legacy_version_bytes, net)
 
-    address(public_key, version_byte)
+    address(public_key, version_byte, opts)
   end
 
-  def address(public_key, version_byte) do
+  def address(public_key, version_byte, opts) do
     {:ok, address} =
       public_key
-      |> Utils.compress_public_key()
+      |> maybe_use_uncompressed_key(opts)
       |> Utils.hash160()
       |> ExBase58.encode_check_version(version_byte)
 
     address
+  end
+
+  def maybe_use_uncompressed_key(%Key{key: key, type: :public}, uncompressed: true), do: key
+
+  def maybe_use_uncompressed_key(key, _opts) do
+    Utils.compress_public_key(key)
   end
 end

--- a/lib/cryptopunk/crypto/bitcoin/legacy_address.ex
+++ b/lib/cryptopunk/crypto/bitcoin/legacy_address.ex
@@ -10,6 +10,8 @@ defmodule Cryptopunk.Crypto.Bitcoin.LegacyAddress do
   }
 
   @spec address(Key.t(), atom() | binary(), Keyword.t()) :: String.t()
+  def address(public_key, net, opts \\ [])
+
   def address(public_key, net, opts) when is_atom(net) do
     version_byte = Map.fetch!(@legacy_version_bytes, net)
 

--- a/lib/cryptopunk/crypto/dogecoin.ex
+++ b/lib/cryptopunk/crypto/dogecoin.ex
@@ -14,10 +14,11 @@ defmodule Cryptopunk.Crypto.Dogecoin do
   @doc """
   Generate a dogecoin address.
 
-  It accepts two parameters:
+  It accepts three parameters:
 
   - public or private key. if a private key is provided, it will be converted to public key.
   - network (`:mainnet` or `:testnet`)
+  - optional keyword params. Currently, the only allowed parameter is `:uncompressed` key. Passing `[uncompressed: true]` will generate the address from the uncompressed public key which is not advised. but it may be required for compatibility reasons
 
   Examples:
 
@@ -28,6 +29,10 @@ defmodule Cryptopunk.Crypto.Dogecoin do
       iex> public_key = %Cryptopunk.Key{key: <<4, 57, 163, 96, 19, 48, 21, 151, 218, 239, 65, 251, 229, 147, 160, 44, 197, 19, 208, 181, 85, 39, 236, 45, 241, 5, 14, 46, 143, 244, 156, 133, 194, 60, 190, 125, 237, 14, 124, 230, 165, 148, 137, 107, 143, 98, 136, 143, 219, 197, 200, 130, 19, 5, 226, 234, 66, 191, 1, 227, 115, 0, 17, 98, 129>>, type: :public}
       iex> Cryptopunk.Crypto.Dogecoin.address(public_key, :testnet)
       "nYxUariD3FNhvYrgVHGQk6y68aBtLHP87b"
+
+      iex> private_key = %Cryptopunk.Key{key: <<16, 42, 130, 92, 247, 244, 62, 96, 24, 129, 187, 141, 124, 42, 176, 116, 234, 171, 184, 107, 3, 229, 255, 72, 30, 116, 79, 243, 36, 142, 184, 24>>, type: :private}
+      iex> Cryptopunk.Crypto.Dogecoin.address(private_key, :mainnet, uncompressed: true)
+      "DEyc1dTk53Uzvb9fomq89vXSFZxc2ZcRbs"
   """
   @spec address(Key.t(), atom(), Keyword.t()) :: String.t()
   def address(private_or_public_key, net, opts \\ []) do

--- a/lib/cryptopunk/crypto/dogecoin.ex
+++ b/lib/cryptopunk/crypto/dogecoin.ex
@@ -29,10 +29,10 @@ defmodule Cryptopunk.Crypto.Dogecoin do
       iex> Cryptopunk.Crypto.Dogecoin.address(public_key, :testnet)
       "nYxUariD3FNhvYrgVHGQk6y68aBtLHP87b"
   """
-  @spec address(Key.t(), atom()) :: String.t()
-  def address(private_or_public_key, net) do
+  @spec address(Key.t(), atom(), Keyword.t()) :: String.t()
+  def address(private_or_public_key, net, opts \\ []) do
     version_byte = Map.fetch!(@version_bytes, net)
 
-    Bitcoin.legacy_address(private_or_public_key, version_byte)
+    Bitcoin.legacy_address(private_or_public_key, version_byte, opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Cryptopunk.MixProject do
   def project do
     [
       app: :cryptopunk,
-      version: "0.5.1",
+      version: "0.5.2",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/cryptopunk/crypto/bitcoin_test.exs
+++ b/test/cryptopunk/crypto/bitcoin_test.exs
@@ -30,6 +30,29 @@ defmodule Cryptopunk.Crypto.BitcoinTest do
       assert "15HJfZhj5V9qQeyvFxPxMWNzRbcZpFUAaA" ==
                Bitcoin.legacy_address(derived_public_key, :mainnet)
     end
+
+    test "generates address from uncompressed public key" do
+      public_key = %Cryptopunk.Key{
+        chain_code:
+          <<184, 11, 206, 224, 102, 96, 47, 80, 46, 138, 85, 56, 176, 38, 61, 128, 29, 175, 239,
+            140, 82, 86, 80, 48, 90, 182, 192, 180, 100, 69, 49, 128>>,
+        depth: 5,
+        index: 0,
+        key:
+          <<4, 24, 46, 89, 53, 195, 145, 241, 19, 7, 237, 101, 67, 103, 24, 237, 71, 59, 96, 213,
+            38, 203, 90, 197, 19, 54, 100, 111, 138, 147, 230, 116, 172, 115, 191, 63, 16, 149,
+            104, 132, 201, 171, 19, 104, 7, 197, 136, 141, 243, 217, 190, 97, 123, 94, 5, 135, 82,
+            10, 195, 207, 205, 156, 48, 246, 39>>,
+        parent_fingerprint: <<115, 62, 87, 238>>,
+        type: :public
+      }
+
+      assert "18ejJd8nqhYbtY4Z6arYL21LetCS6fwbpM" ==
+               Bitcoin.legacy_address(public_key, :mainnet, uncompressed: true)
+
+      assert "moAgbgDmeiyrfeYAp9pv9wDfWso8yVYSjP" ==
+               Bitcoin.legacy_address(public_key, :testnet, uncompressed: true)
+    end
   end
 
   describe "p2sh_p2wpkh_address/2" do

--- a/test/cryptopunk/crypto/dogecoin_test.exs
+++ b/test/cryptopunk/crypto/dogecoin_test.exs
@@ -34,4 +34,22 @@ defmodule Cryptopunk.Crypto.DogecoinTest do
 
     assert "DPiwFnkrUPGfQ2Uk9jsAVJMuN3RV9t8CMz" == address
   end
+
+  test "generates mainnet address from uncompressed public key", %{master_key: master_key} do
+    {:ok, path} = Cryptopunk.parse_path("m/44'/3'/0'/0/0")
+    key = Cryptopunk.derive_key(master_key, path)
+
+    address = Dogecoin.address(key, :mainnet, uncompressed: true)
+
+    assert "DT2YycR1ga7CcfjY9bg5C4aKmgCfAvJ9qJ" == address
+  end
+
+  test "generates testnet address from uncompressed public key", %{master_key: master_key} do
+    {:ok, path} = Cryptopunk.parse_path("m/44'/1'/0'/0/0")
+    key = Cryptopunk.derive_key(master_key, path)
+
+    address = Dogecoin.address(key, :testnet, uncompressed: true)
+
+    assert "novv696ZrbrphW1ZK4WA3KgWrJeHJTJdQ1" == address
+  end
 end


### PR DESCRIPTION
Uncompressed keys were used in the initial bitcoin implementation